### PR TITLE
Error "Fatal: convert to string not implemented for this type"

### DIFF
--- a/library-crypto/CryptExternalMethods.cpp
+++ b/library-crypto/CryptExternalMethods.cpp
@@ -324,6 +324,10 @@ int create_algo_MD5_radius(char          *  P_msg,
                            int              P_msg_size,
                            char          *  P_shared_secret,
                            unsigned char *  P_result) {
+  int        L_ret         = 0 ;
+  int        L_size_shared = 0 ;
+  char       *p, *msg_secret;
+  
   //MD5_CTX    L_Md5Ctx ;
 
   if (P_shared_secret != NULL) {

--- a/library-crypto/CryptExternalMethods.cpp
+++ b/library-crypto/CryptExternalMethods.cpp
@@ -324,22 +324,28 @@ int create_algo_MD5_radius(char          *  P_msg,
                            int              P_msg_size,
                            char          *  P_shared_secret,
                            unsigned char *  P_result) {
-  int        L_ret         = 0 ;
-  int        L_size_shared = 0 ;
-  
-  MD5_CTX    L_Md5Ctx ;
+  //MD5_CTX    L_Md5Ctx ;
 
   if (P_shared_secret != NULL) {
     L_size_shared = strlen(P_shared_secret);
   }
 
+  /*
   MD5_Init(&L_Md5Ctx);
-   MD5_Update(&L_Md5Ctx, P_msg, P_msg_size);
   if (L_size_shared > 0) {
     MD5_Update(&L_Md5Ctx, P_shared_secret, L_size_shared);
   }
- 
+  MD5_Update(&L_Md5Ctx, P_msg, P_msg_size);
   MD5_Final(P_result, &L_Md5Ctx);
+  */
+
+  msg_secret = (char *)malloc(P_msg_size + L_size_shared);
+  memcpy(msg_secret, P_msg, P_msg_size);
+  p = msg_secret + P_msg_size;
+  memcpy(p, P_shared_secret, L_size_shared);
+
+  MD5((unsigned char *)msg_secret, P_msg_size + L_size_shared, P_result);
+  free(msg_secret);
 
   return (L_ret);
 }


### PR DESCRIPTION
After I fixed the authenticator problem in Radius accounting REQ message, I was able to get Radius accounting response from server when I sent Radius accounting REQ message using Seagull as a client.

But I encountered a new problem during Seagull processed the response message. 
Fatal: convert to string not implemented for this type.

I wonder if this related to that there is no "Acct-Session-Id" field in my response message.
